### PR TITLE
RELEASE: Add wandb runs restarting, improve metrics, hide bittensor header trace log

### DIFF
--- a/fakenews/base/utils/weight_utils.py
+++ b/fakenews/base/utils/weight_utils.py
@@ -70,10 +70,10 @@ def convert_weights_and_uids_for_emit(uids: np.ndarray, weights: np.ndarray) -> 
     non_zero_weight_uids = uids[weights > 0]
 
     # Debugging information
-    bittensor.logging.debug(f"weights: {weights}")
-    bittensor.logging.debug(f"non_zero_weights: {non_zero_weights}")
-    bittensor.logging.debug(f"uids: {uids}")
-    bittensor.logging.debug(f"non_zero_weight_uids: {non_zero_weight_uids}")
+    bittensor.logging.debug(f"weights: {weights.tolist()}")
+    bittensor.logging.debug(f"non_zero_weights: {non_zero_weights.tolist()}")
+    bittensor.logging.debug(f"uids: {uids.tolist()}")
+    bittensor.logging.debug(f"non_zero_weight_uids: {non_zero_weight_uids.tolist()}")
 
     if np.min(weights) < 0:
         raise ValueError("Passed weight is negative cannot exist on chain {}".format(weights))
@@ -123,7 +123,7 @@ def process_weights_for_netuid(
     tuple[Any, ndarray],
 ]:
     bittensor.logging.debug("process_weights_for_netuid()")
-    bittensor.logging.debug("weights", weights)
+    bittensor.logging.debug("weights", weights.tolist())
     bittensor.logging.debug("netuid", netuid)
     bittensor.logging.debug("subtensor", subtensor)
     bittensor.logging.debug("metagraph", metagraph)
@@ -153,14 +153,14 @@ def process_weights_for_netuid(
     if non_zero_weights.size == 0 or metagraph.n < min_allowed_weights:
         bittensor.logging.warning("No non-zero weights returning all ones.")
         final_weights = np.ones(metagraph.n) / metagraph.n
-        bittensor.logging.debug("final_weights", final_weights)
+        bittensor.logging.debug("final_weights", final_weights.tolist())
         return np.arange(len(final_weights)), final_weights
 
     if non_zero_weights.size < min_allowed_weights:
         bittensor.logging.warning("No non-zero weights less then min allowed weight, returning all ones.")
         weights = np.ones(metagraph.n) * 1e-5  # creating minimum even non-zero weights
         weights[non_zero_weight_idx] += non_zero_weights
-        bittensor.logging.debug("final_weights", weights)
+        bittensor.logging.debug("final_weights", weights.tolist())
         normalized_weights = normalize_max_weight(x=weights, limit=max_weight_limit)
         return np.arange(len(normalized_weights)), normalized_weights
 

--- a/fakenews/base/utils/weight_utils.py
+++ b/fakenews/base/utils/weight_utils.py
@@ -164,7 +164,7 @@ def process_weights_for_netuid(
         normalized_weights = normalize_max_weight(x=weights, limit=max_weight_limit)
         return np.arange(len(normalized_weights)), normalized_weights
 
-    bittensor.logging.debug("non_zero_weights", non_zero_weights)
+    bittensor.logging.debug("non_zero_weights", non_zero_weights.tolist())
 
     # Compute the exclude quantile and find the weights in the lowest quantile
     max_exclude = max(0, len(non_zero_weights) - min_allowed_weights) / len(non_zero_weights)
@@ -177,11 +177,11 @@ def process_weights_for_netuid(
     # Exclude all weights below the allowed quantile.
     non_zero_weight_uids = non_zero_weight_uids[lowest_quantile <= non_zero_weights]
     non_zero_weights = non_zero_weights[lowest_quantile <= non_zero_weights]
-    bittensor.logging.debug("non_zero_weight_uids", non_zero_weight_uids)
-    bittensor.logging.debug("non_zero_weights", non_zero_weights)
+    bittensor.logging.debug("non_zero_weight_uids", non_zero_weight_uids.tolist())
+    bittensor.logging.debug("non_zero_weights", non_zero_weights.tolist())
 
     # Normalize weights and return.
     normalized_weights = normalize_max_weight(x=non_zero_weights, limit=max_weight_limit)
-    bittensor.logging.debug("final_weights", normalized_weights)
+    bittensor.logging.debug("final_weights", normalized_weights.tolist())
 
     return non_zero_weight_uids, normalized_weights

--- a/fakenews/base/validator.py
+++ b/fakenews/base/validator.py
@@ -178,7 +178,7 @@ class BaseValidatorNeuron(BaseNeuron):
                 if not self.config.wandb.off:
                     if (dt.datetime.now() - self.wandb_run_start) >= dt.timedelta(hours=restart_wandb_every_hours):
                         bt.logging.info(
-                            f"Current wandb run is more than {restart_wandb_every_hours} day old. Starting a new run."
+                            f"Current wandb run is more than {restart_wandb_every_hours} hours old. Starting a new run."
                         )
                         self.wandb_run.finish()
                         self.init_wandb()

--- a/fakenews/base/validator.py
+++ b/fakenews/base/validator.py
@@ -228,8 +228,6 @@ class BaseValidatorNeuron(BaseNeuron):
             self.thread.join(5)
             self.is_running = False
             bt.logging.debug("Stopped")
-            if not self.config.wandb.off:
-                self.wandb_run.finish()
 
     def __enter__(self):
         self.run_in_background_thread()
@@ -254,8 +252,6 @@ class BaseValidatorNeuron(BaseNeuron):
             self.thread.join(5)
             self.is_running = False
             bt.logging.debug("Stopped")
-            if not self.config.wandb.off:
-                self.wandb_run.finish()
 
     def set_weights(self):
         """

--- a/fakenews/base/validator.py
+++ b/fakenews/base/validator.py
@@ -193,6 +193,8 @@ class BaseValidatorNeuron(BaseNeuron):
             except KeyboardInterrupt:
                 self.axon.stop()
                 bt.logging.success("Validator killed by keyboard interrupt.")
+                if not self.config.wandb.off:
+                    self.wandb_run.finish()
                 sys.exit()
 
             # In case of unforeseen errors, the validator will log the error and continue operations.

--- a/fakenews/base/validator.py
+++ b/fakenews/base/validator.py
@@ -453,11 +453,6 @@ class BaseValidatorNeuron(BaseNeuron):
         self.wandb_run_start = now
         run_id = now.strftime("%Y-%m-%d_%H-%M-%S")
         run_name = f"validator-{self.uid}-{run_id}"
-        self.config.run_name = run_name
-        self.config.uid = self.uid
-        self.config.hotkey = self.wallet.hotkey.ss58_address
-        self.config.version = fakenews.__version__
-        self.config.type = self.neuron_type
 
         # Initialize the wandb run for the single project
         bt.logging.info(f"Initializing W&B run")
@@ -469,8 +464,9 @@ class BaseValidatorNeuron(BaseNeuron):
                 config={
                     "uid": self.uid,
                     "hotkey": self.wallet.hotkey.ss58_address,
-                    "run_name": run_id,
-                    "type": "validator",
+                    "run_name": run_name,
+                    "version": fakenews.__version__,
+                    "type": self.neuron_type,
                 },
                 allow_val_change=True,
                 dir=self.config.full_path,

--- a/fakenews/base/validator.py
+++ b/fakenews/base/validator.py
@@ -164,6 +164,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # Check that validator is registered on the network.
         self.sync()
 
+        restart_wandb_every_hours = 12
         bt.logging.info(f"Validator starting at block: {self.block}")
 
         # This loop maintains the validator's operations until intentionally stopped.
@@ -175,8 +176,10 @@ class BaseValidatorNeuron(BaseNeuron):
                 self.loop.run_until_complete(self.concurrent_forward())
 
                 if not self.config.wandb.off:
-                    if (dt.datetime.now() - self.wandb_run_start) >= dt.timedelta(hours=12):
-                        bt.logging.info("Current wandb run is more than 1 day old. Starting a new run.")
+                    if (dt.datetime.now() - self.wandb_run_start) >= dt.timedelta(hours=restart_wandb_every_hours):
+                        bt.logging.info(
+                            f"Current wandb run is more than {restart_wandb_every_hours} day old. Starting a new run."
+                        )
                         self.wandb_run.finish()
                         self.init_wandb()
 

--- a/fakenews/base/validator.py
+++ b/fakenews/base/validator.py
@@ -173,7 +173,7 @@ class BaseValidatorNeuron(BaseNeuron):
                 self.loop.run_until_complete(self.concurrent_forward())
 
                 if not self.config.wandb.off:
-                    if (dt.datetime.now() - self.wandb_run_start) >= dt.timedelta(days=1):
+                    if (dt.datetime.now() - self.wandb_run_start) >= dt.timedelta(hours=12):
                         bt.logging.info("Current wandb run is more than 1 day old. Starting a new run.")
                         self.wandb_run.finish()
                         self.init_wandb()

--- a/fakenews/services/news_api.py
+++ b/fakenews/services/news_api.py
@@ -53,7 +53,6 @@ class NewsAPIClient:
                     self.SAVE_ARTICLES_DATASET_URL, auth=self._auth, json=dataset, timeout=ClientTimeout(3)
                 ) as response,
             ):
-                bt.logging.info(f"Response status: {response.status}")
                 response.raise_for_status()
         except BaseException as e:
             bt.logging.warning(f"Error while saving dataset: {e}")

--- a/fakenews/services/openai/client.py
+++ b/fakenews/services/openai/client.py
@@ -17,7 +17,6 @@ class OpenAIClient(AsyncOpenAI):
         return prompt.normalize_result(result)
 
     async def _get_completions_async(self, messages: list[dict], model: str) -> str:
-        logging.debug(f"Prompt: {messages}")
         try:
             completions = await self.chat.completions.create(
                 model=model,
@@ -36,5 +35,4 @@ class OpenAIClient(AsyncOpenAI):
             logging.error(f"Failed to get completions from OpenAI: {e}")
             raise e
 
-        logging.debug(f"Response: {response}")
         return response

--- a/fakenews/validator/forward.py
+++ b/fakenews/validator/forward.py
@@ -76,7 +76,8 @@ async def forward(self: BaseValidatorNeuron):
         wandb_logging_context = {
             "rewards": rewards.tolist(),
             "rewards_calculating_metadata": calculating_metadata,
-            "scores": self.scores,
+            "miner_uids": miner_uids,
+            "scores": self.scores.tolist(),
             "responses": responses,
             "labels": labels,
             "task_metadata": task.metadata(),

--- a/fakenews/validator/forward.py
+++ b/fakenews/validator/forward.py
@@ -29,7 +29,7 @@ from fakenews.validator.task import ValidatorTask, select_task
 
 async def forward(self: BaseValidatorNeuron):
     miner_uids = uids.get_random_uids(self, k=self.config.neuron.sample_size)
-    bt.logging.info(f"Miners: {miner_uids}")
+    bt.logging.info(f"Miners: {miner_uids.tolist()}")
     axons = [self.metagraph.axons[uid] for uid in miner_uids]
 
     if len(miner_uids) == 0:
@@ -66,7 +66,7 @@ async def forward(self: BaseValidatorNeuron):
         current_task=task,
     )
 
-    bt.logging.info(f"Scored responses: {rewards}")
+    bt.logging.info(f"Scored responses: {rewards.tolist()}")
 
     self.update_scores(rewards, miner_uids)
     self.save_miner_history()

--- a/fakenews/validator/forward.py
+++ b/fakenews/validator/forward.py
@@ -52,10 +52,9 @@ async def forward(self: BaseValidatorNeuron):
         deserialize=True,
         timeout=15,
     )
-    bt.logging.info(f"Responses received in {time.perf_counter() - start:.2f} seconds")
 
     # Log the results for monitoring purposes.
-    bt.logging.info(f"Received responses: {responses}")
+    bt.logging.info(f"Received responses in {time.perf_counter() - start:.2f} seconds: {responses}")
 
     # Adjust the scores based on responses from miners.
     rewards, calculating_metadata = RewardCalculator.get_rewards(

--- a/fakenews/validator/forward.py
+++ b/fakenews/validator/forward.py
@@ -75,7 +75,7 @@ async def forward(self: BaseValidatorNeuron):
         wandb_logging_context = {
             "rewards": rewards.tolist(),
             "rewards_calculating_metadata": calculating_metadata,
-            "miner_uids": miner_uids,
+            "miner_uids": miner_uids.tolist(),
             "scores": self.scores.tolist(),
             "responses": responses,
             "labels": labels,

--- a/fakenews/validator/task/fakenews_detection_with_original.py
+++ b/fakenews/validator/task/fakenews_detection_with_original.py
@@ -90,6 +90,8 @@ class FakenewsDetectionWithOriginal(ValidatorTask):
         original_article = await self._news_api_client.fetch_article()
 
         article_text = original_article.body
+        log_article = article_text.replace('\n', ' ')
+        bt.logging.debug(f"Original article url: {original_article.url}, text: {log_article}")
 
         prompts = [p(article_text) for p in self._select_sampled_prompts()]
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -148,9 +148,7 @@ class Miner(BaseMinerNeuron):
 
     def print_running_info(self):
         metagraph = self.metagraph
-        self.uid = self.metagraph.hotkeys.index(
-                self.wallet.hotkey.ss58_address
-            )
+        self.uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
 
         log = (
             "Miner | "
@@ -162,6 +160,7 @@ class Miner(BaseMinerNeuron):
             f"Emission:{metagraph.E[self.uid]:.4f}"
         )
         bt.logging.info(log)
+
 
 # This is the main function, which runs the miner.
 if __name__ == "__main__":

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -48,4 +48,4 @@ if __name__ == "__main__":
     with Validator() as validator:
         while True:
             bt.logging.info(f"Validator running... {time.time()}")
-            time.sleep(5)
+            time.sleep(60)

--- a/scripts/start_validator.sh
+++ b/scripts/start_validator.sh
@@ -57,7 +57,6 @@ CMD+=" --netuid $NETUID"
 CMD+=" --subtensor.network $SUBTENSOR_NETWORK"
 CMD+=" --wallet.name $WALLET_NAME"
 CMD+=" --wallet.hotkey $WALLET_HOTKEY"
-CMD+=" --openai_api_key $OPENAI_API_KEY"
 CMD+=" --logging.trace"
 
 # Conditionally add optional arguments


### PR DESCRIPTION
# RELEASE NOTES:

## Validator:
- Validator WandB Auto-Restart: Validator's Weights & Biases (WandB) runs now automatically restart every 12 hours, ensuring continuous tracking and logging.
- Improved WandB Metrics: Enhanced monitoring with additional metrics, including scores and miner UIDs for better insights.
- Optimized Console Logging: Console log messages for WandB have been refined for a.
- Graceful WandB Run Termination: Ensures WandB runs are properly closed upon completion, preventing unexpected interruptions.
- Removed Bittensor core trace console log: "Unexpected header key encountered" to reduce noise.
- Removed OpenAI prompt and response logs.
- Refactored WandB run initialization