### PR TITLE
[Feature] Hide prompt logging, add graceful finish for wandb run

### DIFF
--- a/fakenews/base/validator.py
+++ b/fakenews/base/validator.py
@@ -43,10 +43,15 @@ from fakenews.validator.performance_tracker import PerformanceTracker
 
 # Temporary solution to getting rid of annoying bittensor trace logs
 original_trace = bt.logging.trace
+
+
 def filtered_trace(message, *args, **kwargs):
     if "Unexpected header key encountered" not in message:
         original_trace(message, *args, **kwargs)
+
+
 bt.logging.trace = filtered_trace
+
 
 class BaseValidatorNeuron(BaseNeuron):
     """
@@ -168,12 +173,8 @@ class BaseValidatorNeuron(BaseNeuron):
                 self.loop.run_until_complete(self.concurrent_forward())
 
                 if not self.config.wandb.off:
-                    if (dt.datetime.now() - self.wandb_run_start) >= dt.timedelta(
-                        days=1
-                    ):
-                        bt.logging.info(
-                            "Current wandb run is more than 1 day old. Starting a new run."
-                        )
+                    if (dt.datetime.now() - self.wandb_run_start) >= dt.timedelta(days=1):
+                        bt.logging.info("Current wandb run is more than 1 day old. Starting a new run.")
                         self.wandb_run.finish()
                         self.init_wandb()
 

--- a/fakenews/base/validator.py
+++ b/fakenews/base/validator.py
@@ -19,6 +19,7 @@
 import argparse
 import asyncio
 import copy
+import datetime as dt
 import os
 import sys
 import threading
@@ -40,6 +41,12 @@ from fakenews.utils.config import add_validator_args
 from fakenews.validator import task as tasks
 from fakenews.validator.performance_tracker import PerformanceTracker
 
+# Temporary solution to getting rid of annoying bittensor trace logs
+original_trace = bt.logging.trace
+def filtered_trace(message, *args, **kwargs):
+    if "Unexpected header key encountered" not in message:
+        original_trace(message, *args, **kwargs)
+bt.logging.trace = filtered_trace
 
 class BaseValidatorNeuron(BaseNeuron):
     """
@@ -159,6 +166,16 @@ class BaseValidatorNeuron(BaseNeuron):
 
                 # Run multiple forwards concurrently.
                 self.loop.run_until_complete(self.concurrent_forward())
+
+                if not self.config.wandb.off:
+                    if (dt.datetime.now() - self.wandb_run_start) >= dt.timedelta(
+                        days=1
+                    ):
+                        bt.logging.info(
+                            "Current wandb run is more than 1 day old. Starting a new run."
+                        )
+                        self.wandb_run.finish()
+                        self.init_wandb()
 
                 # Check if we should exit.
                 if self.should_exit:
@@ -426,7 +443,10 @@ class BaseValidatorNeuron(BaseNeuron):
         if self.config.wandb.off:
             return
 
-        run_name = f"validator-{self.uid}-{fakenews.__version__}"
+        now = dt.datetime.now()
+        self.wandb_run_start = now
+        run_id = now.strftime("%Y-%m-%d_%H-%M-%S")
+        run_name = f"validator-{self.uid}-{run_id}"
         self.config.run_name = run_name
         self.config.uid = self.uid
         self.config.hotkey = self.wallet.hotkey.ss58_address
@@ -436,13 +456,12 @@ class BaseValidatorNeuron(BaseNeuron):
         # Initialize the wandb run for the single project
         bt.logging.info(f"Initializing W&B run")
         try:
-            run = wandb.init(
+            self.wandb_run = wandb.init(
                 name=run_name,
                 project=self.config.wandb.project,
                 entity=self.config.wandb.entity,
                 config=self.config,
                 dir=self.config.full_path,
-                reinit=True,
             )
         except wandb.Error as e:
             bt.logging.warning(e)
@@ -451,7 +470,7 @@ class BaseValidatorNeuron(BaseNeuron):
             return
 
         # Sign the run to ensure it's from the correct hotkey
-        signature = self.wallet.hotkey.sign(run.id.encode()).hex()
+        signature = self.wallet.hotkey.sign(self.wandb_run.id.encode()).hex()
         self.config.signature = signature
         wandb.config.update(self.config, allow_val_change=True)
 

--- a/fakenews/base/validator.py
+++ b/fakenews/base/validator.py
@@ -193,6 +193,8 @@ class BaseValidatorNeuron(BaseNeuron):
             except KeyboardInterrupt:
                 self.axon.stop()
                 bt.logging.success("Validator killed by keyboard interrupt.")
+                if not self.config.wandb.off:
+                    self.wandb_run.finish()
                 sys.exit()
 
             # In case of unforeseen errors, the validator will log the error and continue operations.

--- a/fakenews/services/openai/client.py
+++ b/fakenews/services/openai/client.py
@@ -17,7 +17,6 @@ class OpenAIClient(AsyncOpenAI):
         return prompt.normalize_result(result)
 
     async def _get_completions_async(self, messages: list[dict], model: str) -> str:
-        logging.debug(f"Prompt: {messages}")
         try:
             completions = await self.chat.completions.create(
                 model=model,
@@ -36,5 +35,4 @@ class OpenAIClient(AsyncOpenAI):
             logging.error(f"Failed to get completions from OpenAI: {e}")
             raise e
 
-        logging.debug(f"Response: {response}")
         return response

--- a/fakenews/validator/forward.py
+++ b/fakenews/validator/forward.py
@@ -76,7 +76,8 @@ async def forward(self: BaseValidatorNeuron):
         wandb_logging_context = {
             "rewards": rewards.tolist(),
             "rewards_calculating_metadata": calculating_metadata,
-            "scores": self.scores,
+            "miner_uids": miner_uids,
+            "scores": self.scores.tolist(),
             "responses": responses,
             "labels": labels,
             "task_metadata": task.metadata(),

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -148,9 +148,7 @@ class Miner(BaseMinerNeuron):
 
     def print_running_info(self):
         metagraph = self.metagraph
-        self.uid = self.metagraph.hotkeys.index(
-                self.wallet.hotkey.ss58_address
-            )
+        self.uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
 
         log = (
             "Miner | "
@@ -162,6 +160,7 @@ class Miner(BaseMinerNeuron):
             f"Emission:{metagraph.E[self.uid]:.4f}"
         )
         bt.logging.info(log)
+
 
 # This is the main function, which runs the miner.
 if __name__ == "__main__":


### PR DESCRIPTION
1. Remove prompt and generated versions response from logging
2. Add graceful finish for wandb run on exit