### PR TITLE
RELEASE: Add miners minimum alpha restriction

### DIFF
--- a/fakenews/__init__.py
+++ b/fakenews/__init__.py
@@ -16,7 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "0.0.0"
+__version__ = "0.1.0"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/fakenews/base/utils/min_miners_alpha.py
+++ b/fakenews/base/utils/min_miners_alpha.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import bittensor as bt
+
+MINERS_MINIMUM_ALPHA_BASE = 150
+MINERS_MINIMUM_ALPHA_ENABLE_DATE = "2025-03-20T00:00:00+00:00"
+MINERS_MINIMUM_ALPHA_DAILY_INCREASE = 6
+
+
+def calculate_minimum_miner_alpha() -> int:
+    considering_days = (datetime.now(tz=timezone.utc) - datetime.fromisoformat(MINERS_MINIMUM_ALPHA_ENABLE_DATE)).days
+    return MINERS_MINIMUM_ALPHA_BASE + MINERS_MINIMUM_ALPHA_DAILY_INCREASE * considering_days

--- a/fakenews/base/validator.py
+++ b/fakenews/base/validator.py
@@ -406,7 +406,7 @@ class BaseValidatorNeuron(BaseNeuron):
             )
 
         rewards = rewards * self.has_enough_stake[uids_array]
-        bt.logging.debug(f"Rewards after considering minimum miner alpha amount: {rewards}")
+        bt.logging.debug(f"Rewards after considering minimum miner alpha amount: {rewards.tolist()}")
 
         # Update scores with rewards produced by this step.
         alpha: float = self.config.neuron.moving_average_alpha

--- a/fakenews/validator/reward.py
+++ b/fakenews/validator/reward.py
@@ -14,8 +14,8 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-from collections import defaultdict
 import math
+from collections import defaultdict
 from typing import Final
 
 import bittensor as bt
@@ -67,7 +67,6 @@ class RewardCalculator:
             normalized_probs = cls._normalize_miner_probs(probs, labels)
 
             for task, performance_tracker in performance_trackers.items():
-
                 if task == current_task:
                     for normalized_score, label in zip(normalized_probs, labels):
                         performance_tracker.update(uid, normalized_score, label, hotkey)
@@ -122,24 +121,28 @@ class RewardCalculator:
         normalized_metadata = defaultdict(list)
         for miner_metadata in miner_rewards_calculating_metadata:
             for task_name, metadata in miner_metadata.items():
-                normalized_metadata[task_name].append({
-                    "uid": metadata["miner_uid"],
-                    "probs": metadata["probabilities"],
-                    "long": metadata["metrics_long"],
-                    "short": metadata["metrics_short"],
-                    "wght_rwd": metadata["weighted_reward"],
-                })
+                normalized_metadata[task_name].append(
+                    {
+                        "uid": metadata["miner_uid"],
+                        "probs": metadata["probabilities"],
+                        "long": metadata["metrics_long"],
+                        "short": metadata["metrics_short"],
+                        "wght_rwd": metadata["weighted_reward"],
+                    }
+                )
 
         normalized_metadata = dict(normalized_metadata)
 
-        log_message = f"Calculating rewards for task {current_task.TASK_NAME}. Long alpha: {cls._LONG_ALPHA}, " + \
-            f"long term window: {cls._LONG_TERM_WINDOW}, short term window: {cls._SHORT_TERM_WINDOW}, " + \
-            f"Miner calculating metadata: {str(normalized_metadata).replace(' ', '')}"
+        log_message = (
+            f"Calculating rewards for task {current_task.TASK_NAME}. Long alpha: {cls._LONG_ALPHA}, "
+            + f"long term window: {cls._LONG_TERM_WINDOW}, short term window: {cls._SHORT_TERM_WINDOW}, "
+            + f"Miner calculating metadata: {str(normalized_metadata).replace(' ', '')}"
+        )
 
         max_log_length = 3950
         log_messages = []
         if len(log_message) > max_log_length:
-            log_messages = [log_message[i:i + max_log_length] for i in range(0, len(log_message), max_log_length)]
+            log_messages = [log_message[i : i + max_log_length] for i in range(0, len(log_message), max_log_length)]
         else:
             log_messages = [log_message]
 

--- a/tests/test_fakenews_detection_task.py
+++ b/tests/test_fakenews_detection_task.py
@@ -18,6 +18,4 @@ def test_select_sampled_prompts_1_fake_1_original():
         assert len(prompts) == 2
 
     # assert that all items are unique
-    assert any(
-        prompts != selected_prompts[0] for prompts in selected_prompts
-    )
+    assert any(prompts != selected_prompts[0] for prompts in selected_prompts)


### PR DESCRIPTION
## Validator

- Introduced a minimum alpha restriction for neurons in the subnetwork.
- Base stake requirement: 150
- Daily stake increase: 6
- Applies to all hotkeys registered in the subnetwork, grouped by their associated cold key.
- The required minimum stake is calculated based on the enable date and deducted sequentially per cold key.
- If the remaining stake after deduction is negative, the neuron's reward will be reset during scoring updates.
- Neurons with insufficient stake retain their responses and accuracy, enabling miners to replenish their stake without significant loss in metagraph weight.

## Miner

Implemented a validator-like check that will output a critical log in case a miner, based on the current day's calculations, will receive penalties when scoring.